### PR TITLE
Show tire history for retired drivers

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,23 +79,26 @@ function renderDrivers() {
         const tyresContainer = document.createElement('div');
         tyresContainer.className = 'tyres-container';
 
-        // Add RETIRED badge if driver is retired
-        if (driver.retired) {
-            const retiredBadge = document.createElement('div');
-            retiredBadge.className = 'retired-badge';
-            retiredBadge.textContent = 'RETIRED';
-            tyresContainer.appendChild(retiredBadge);
-        } else {
-            driver.tyres.forEach((tyre, tyreIndex) => {
-                const tyreBadge = document.createElement('div');
-                tyreBadge.className = `tyre-badge tyre-${tyre}`;
-                tyreBadge.textContent = tyre;
-                tyreBadge.onclick = (e) => {
-                    e.stopPropagation();
+        // Show tyres for all drivers
+        driver.tyres.forEach((tyre, tyreIndex) => {
+            const tyreBadge = document.createElement('div');
+            tyreBadge.className = driver.retired ? `tyre-badge tyre-${tyre} retired-tyre` : `tyre-badge tyre-${tyre}`;
+            tyreBadge.textContent = tyre;
+            tyreBadge.onclick = (e) => {
+                e.stopPropagation();
+                if (!driver.retired) {
                     removeTyre(index, tyreIndex);
-                };
-                tyresContainer.appendChild(tyreBadge);
-            });
+                }
+            };
+            tyresContainer.appendChild(tyreBadge);
+        });
+        
+        // Add OUT label if driver is retired
+        if (driver.retired) {
+            const outLabel = document.createElement('div');
+            outLabel.className = 'out-label';
+            outLabel.textContent = 'OUT';
+            tyresContainer.appendChild(outLabel);
         }
 
         driverRow.appendChild(driverNumber);

--- a/style.css
+++ b/style.css
@@ -400,20 +400,30 @@ header h1 {
 
 /* Retired drivers styles */
 .driver-row.retired {
-    opacity: 0.5;
-}
-
-.driver-row.retired:hover {
     opacity: 0.7;
 }
 
-.retired-badge {
-    background-color: #666;
-    color: #fff;
-    padding: 4px 12px;
-    border-radius: 4px;
+.driver-row.retired:hover {
+    opacity: 0.8;
+}
+
+/* Retired tyre badges */
+.tyre-badge.retired-tyre {
+    opacity: 0.5;
+}
+
+.tyre-badge.retired-tyre:hover {
+    cursor: default;
+    transform: none;
+}
+
+/* OUT label for retired drivers */
+.out-label {
+    color: #666;
     font-size: 0.9rem;
-    font-weight: bold;
+    font-weight: normal;
+    margin-left: 8px;
+    align-self: center;
 }
 
 /* Disabled select */


### PR DESCRIPTION
## Summary
- リタイアしたドライバーのタイヤ交換履歴を薄く表示
- 履歴の横に薄いグレーで「OUT」ラベルを表示
- REITREDバッジを削除し、より控えめな表示に変更

## Changes
- リタイアしたドライバーでもタイヤ履歴を表示（opacity: 0.5）
- タイヤバッジの横に「OUT」テキストを追加（グレー、背景なし）
- リタイア時はタイヤバッジのクリックを無効化

🤖 Generated with [Claude Code](https://claude.ai/code)