### PR TITLE
Adjust retired driver visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -400,11 +400,11 @@ header h1 {
 
 /* Retired drivers styles */
 .driver-row.retired {
-    opacity: 0.7;
+    opacity: 0.4;
 }
 
 .driver-row.retired:hover {
-    opacity: 0.8;
+    opacity: 0.5;
 }
 
 /* Retired tyre badges */
@@ -421,7 +421,7 @@ header h1 {
 .out-label {
     color: #666;
     font-size: 0.9rem;
-    font-weight: normal;
+    font-weight: bold;
     margin-left: 8px;
     align-self: center;
 }


### PR DESCRIPTION
## Summary
- リタイアしたドライバーの透明度を調整して区別しやすく
- OUTラベルをboldに変更

## Changes
- リタイアドライバーの opacity を 0.7 → 0.4 に変更
- ホバー時の opacity を 0.8 → 0.5 に変更  
- OUT ラベルを font-weight: bold に変更

🤖 Generated with [Claude Code](https://claude.ai/code)