### PR TITLE
Fix retired driver styling issues

### DIFF
--- a/script.js
+++ b/script.js
@@ -65,8 +65,12 @@ function renderDrivers() {
 
     drivers.forEach((driver, index) => {
         const driverRow = document.createElement('div');
-        driverRow.className = driver.retired ? 'driver-row retired' : 'driver-row';
+        driverRow.className = 'driver-row';
         driverRow.onclick = () => openModal(index);
+
+        // Create inner container for content that needs opacity
+        const driverContent = document.createElement('div');
+        driverContent.className = driver.retired ? 'driver-content retired' : 'driver-content';
 
         const driverNumber = document.createElement('div');
         driverNumber.className = `driver-number team-${driver.team}`;
@@ -101,9 +105,10 @@ function renderDrivers() {
             tyresContainer.appendChild(outLabel);
         }
 
-        driverRow.appendChild(driverNumber);
-        driverRow.appendChild(driverCode);
-        driverRow.appendChild(tyresContainer);
+        driverContent.appendChild(driverNumber);
+        driverContent.appendChild(driverCode);
+        driverContent.appendChild(tyresContainer);
+        driverRow.appendChild(driverContent);
         driversList.appendChild(driverRow);
     });
 }

--- a/style.css
+++ b/style.css
@@ -471,7 +471,7 @@ select:disabled {
         font-size: 1.5rem;
     }
 
-    .driver-row {
+    .driver-content {
         padding: 10px;
     }
 

--- a/style.css
+++ b/style.css
@@ -38,7 +38,6 @@ header h1 {
     display: flex;
     align-items: center;
     padding: 12px 15px;
-    border-bottom: 1px solid #2a2a3a;
     cursor: pointer;
     transition: background-color 0.2s;
     position: relative;
@@ -47,11 +46,12 @@ header h1 {
 .driver-row::after {
     content: '';
     position: absolute;
-    bottom: -1px;
+    bottom: 0;
     left: 0;
     right: 0;
     height: 1px;
     background-color: #2a2a3a;
+    opacity: 1;
 }
 
 .driver-row:hover {

--- a/style.css
+++ b/style.css
@@ -35,7 +35,6 @@ header h1 {
 }
 
 .driver-row {
-    padding: 0;
     border-bottom: 1px solid #2a2a3a;
     cursor: pointer;
     transition: background-color 0.2s;

--- a/style.css
+++ b/style.css
@@ -35,23 +35,21 @@ header h1 {
 }
 
 .driver-row {
+    padding: 0;
+    border-bottom: 1px solid #2a2a3a;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.driver-content {
     display: flex;
     align-items: center;
     padding: 12px 15px;
-    cursor: pointer;
-    transition: background-color 0.2s;
-    position: relative;
+    transition: opacity 0.2s;
 }
 
-.driver-row::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background-color: #2a2a3a;
-    opacity: 1;
+.driver-content.retired {
+    opacity: 0.4;
 }
 
 .driver-row:hover {
@@ -410,11 +408,7 @@ header h1 {
 }
 
 /* Retired drivers styles */
-.driver-row.retired {
-    opacity: 0.4;
-}
-
-.driver-row.retired:hover {
+.driver-row:hover .driver-content.retired {
     opacity: 0.5;
 }
 

--- a/style.css
+++ b/style.css
@@ -41,6 +41,17 @@ header h1 {
     border-bottom: 1px solid #2a2a3a;
     cursor: pointer;
     transition: background-color 0.2s;
+    position: relative;
+}
+
+.driver-row::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background-color: #2a2a3a;
 }
 
 .driver-row:hover {
@@ -419,7 +430,7 @@ header h1 {
 
 /* OUT label for retired drivers */
 .out-label {
-    color: #666;
+    color: #888;
     font-size: 0.9rem;
     font-weight: bold;
     margin-left: 8px;


### PR DESCRIPTION
## Summary
- リタイアドライバーの区切り線の透明度を修正
- OUTラベルの色を少し濃く調整

## Changes
- 区切り線を::after擬似要素で実装し、常に完全な不透明度を保持
- OUTラベルの色を #666 → #888 に変更して視認性向上

🤖 Generated with [Claude Code](https://claude.ai/code)