### PR TITLE
Reset button clears retired status and simplify label

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <!-- Drivers will be populated by JavaScript -->
             </div>
             <div class="reset-container">
-                <button id="resetAllBtn" class="reset-button">RESET ALL TYRES</button>
+                <button id="resetAllBtn" class="reset-button">RESET</button>
             </div>
         </main>
     </div>

--- a/script.js
+++ b/script.js
@@ -211,6 +211,7 @@ function resetAllTyres() {
     if (confirm('すべてのタイヤ履歴をリセットしますか？\nこの操作は取り消せません。')) {
         drivers.forEach(driver => {
             driver.tyres = ['M'];
+            driver.retired = false;
         });
         saveToStorage();
         renderDrivers();


### PR DESCRIPTION
## Summary
- RESET now also clears all drivers' retired status (rejoin), so one tap fully resets the race state
- Renamed button from "RESET ALL TYRES" to "RESET" for brevity

Closes #8

## Test plan
- [x] Retire a driver, then tap RESET — verify the driver is no longer shown as retired
- [x] Confirm tyres are also reset to Medium as before
- [x] Verify button displays "RESET" instead of "RESET ALL TYRES"

🤖 Generated with [Claude Code](https://claude.com/claude-code)